### PR TITLE
Use base64 tag on byte serialization

### DIFF
--- a/src/util/value.rs
+++ b/src/util/value.rs
@@ -303,7 +303,7 @@ where
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok> {
         self.writer.write_start_tag(b"value")?;
-        self.writer.write_safe_tag(b"string", &base64_encode(v))?;
+        self.writer.write_safe_tag(b"base64", &base64_encode(v))?;
         self.writer.write_end_tag(b"value")?;
         Ok(())
     }


### PR DESCRIPTION
On deserialization we read the `base64` tag but on serialization we write with the `string` tag.

This changes to also serialize with the `base64` tag.

Thank you for creating this library!