### PR TITLE
Add "request_from_str" top level function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! Combine with your transport or server of choice for an easy and quick xmlrpc experience.
 
 use quick_xml::{events::Event, Reader, Writer};
-use serde::{Deserialize};
+use serde::Deserialize;
 use serde_transcode::transcode;
 
 mod error;
@@ -138,7 +138,7 @@ pub fn request_from_str(request: &str) -> Result<(String, Vec<Value>)> {
             let mut buf = Vec::new();
             let mut params = Vec::new();
             // Read each parameter into a Value
-            while let Ok(_) = reader.expect_tag(b"param", &mut buf) {
+            while reader.expect_tag(b"param", &mut buf).is_ok() {
                 // This feels wrong / inefficient, but was the best way I could come up with
                 // from looking at the general structure of this code:
                 let mut reader2 = Reader::from_str(&request[reader.buffer_position()..]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ where
 /// Expects an input string which is xmlrpc request body, and parses out the method name and parameters from it.
 /// This function would typically be used by a server to parse incoming requests.
 /// Returns a tuple of (function name, Arguments)
-pub fn request_from_string<T: serde::de::DeserializeOwned>(request: &str) -> Result<(String, T)> {
+pub fn request_from_str<T: serde::de::DeserializeOwned>(request: &str) -> Result<(String, T)> {
     let mut reader = Reader::from_str(request);
     reader.expand_empty_elements(true);
     reader.trim_text(true);
@@ -430,6 +430,6 @@ mod tests {
             </params>
           </methodCall>"#;
 
-        let response: (String, (String, String, Vec<String>)) = request_from_string(val).unwrap();
+        let response: (String, (String, String, Vec<String>)) = request_from_str(val).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-use std::convert::TryFrom;
-
 use quick_xml::{events::Event, Reader, Writer};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize};
 use serde_transcode::transcode;
 
 mod error;
@@ -422,6 +420,7 @@ mod tests {
 
         let (method_name, arg) = request_from_str(&val).unwrap();
         assert_eq!(arg.get(0).unwrap().as_str().unwrap(), "/rosout");
+        assert_eq!(&method_name, "requestTopic");
     }
 
     /// This test is currently failing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,11 @@ where
     }
 }
 
-/// Expects an input string which is xmlrpc request body, and parses out the method name and parameters from it.
+/// Expects an input string which is a valid xmlrpc request body, and parses out the method name and parameters from it.
 /// This function would typically be used by a server to parse incoming requests.
-/// Returns a tuple of (method name, Arguments).
+///   * Returns a tuple of (method name, Arguments) if successful
 /// This does not parse the types of the arguments, as typically the server needs to resolve
-/// the method name prior know expected types.
+/// the method name before it can know the expected types.
 pub fn request_from_str(request: &str) -> Result<(String, Vec<Value>)> {
     let mut reader = Reader::from_str(request);
     reader.expand_empty_elements(true);
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn test_parse_request() {
-        // Example data taken from a ROS node connection negotation
+        // Example data taken from a ROS node connection negotation, and hand simplified for minimum case
         let val = r#"<?xml version=\"1.0\"?>
           <methodCall>
             <methodName>requestTopic</methodName>
@@ -423,8 +423,6 @@ mod tests {
         assert_eq!(&method_name, "requestTopic");
     }
 
-    /// This test is currently failing
-    /// the code adapted from response_to_string is not varadic against multiple params
     #[test]
     fn test_parse_request_multiple_params() {
         // Example data taken from a ROS node connection negotation


### PR DESCRIPTION
Goal of this PR is to add a similar function to `response_from_str` that instead parses a xmlrpc request.

The intent of this API is to allow a server to write code along the following lines:

```rust
let (method, args) = request_from_str(&data)?;
match method {
  "doA" => {
      // Convert args to types expected by doA() and call
   },
  "doB" => {
   }
}
```

To improve this experience in a later MR, I'd like to add some kind of bulk conversion operation for Vec<Value> along the lines of:
```rust
let raw: Vec<Value> = vec![];
let params: (String, u8, u8) = raw.try_into()?;
```

I'm still not 100% sure I like the style of this API, but it is useful.

Would appreciate suggestions on how to not need to create a 2nd Reader in the inner loop of parsing the <params>. 