### PR TITLE
Upgrade quick-xml to 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 anyhow = "1.0"
 base64 = "0.21"
 iso8601 = "0.6"
-quick-xml = "0.17"
+quick-xml = "0.28"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde-transcode = "1.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -99,6 +99,7 @@ pub enum ParseError {
 }
 
 /// Error while encoding XML.
+#[allow(clippy::enum_variant_names)]
 #[derive(ThisError, Debug)]
 pub enum EncodingError {
     #[error("io error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,6 +101,9 @@ pub enum ParseError {
 /// Error while encoding XML.
 #[derive(ThisError, Debug)]
 pub enum EncodingError {
+    #[error("io error: {0}")]
+    IoError(#[from] std::io::Error),
+
     #[error("malformed UTF-8: {0}")]
     Utf8Error(#[from] FromUtf8Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ pub use value::Value;
 ///
 /// assert_eq!(val, "hello world".to_string());
 /// ```
-pub fn response_from_str<T>(input: &str) -> Result<T>
+pub fn response_from_str<'a, T>(input: &'a str) -> Result<T>
 where
-    T: serde::de::DeserializeOwned,
+    T: serde::de::Deserialize<'a>,
 {
     let mut reader = Reader::from_str(input);
     reader.expand_empty_elements(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 //! This library provides a basic API for serializing / deserializng xmlrpc.
 //! Combine with your transport or server of choice for an easy and quick xmlrpc experience.
 
-use quick_xml::{events::Event, Reader, Writer};
+use std::io::Write;
+
+use quick_xml::{events::Event, name::QName, Reader, Writer};
 use serde::Deserialize;
 use serde_transcode::transcode;
 
@@ -36,50 +38,43 @@ where
 
     // Check the first event. This will determine if we're loading a Fault or a
     // Value.
-    let mut buf = Vec::new();
     loop {
-        match reader
-            .read_event(&mut buf)
-            .map_err(error::ParseError::from)?
-        {
+        match reader.read_event().map_err(error::ParseError::from)? {
             Event::Decl(_) => continue,
-            Event::Start(e) if e.name() == b"methodResponse" => {
+            Event::Start(e) if e.name() == QName(b"methodResponse") => {
                 break;
             }
             e => return Err(error::ParseError::UnexpectedEvent(format!("{:?}", e)).into()),
         };
     }
 
-    match reader
-        .read_event(&mut buf)
-        .map_err(error::ParseError::from)?
-    {
-        Event::Start(e) if e.name() == b"params" => {
-            let mut buf = Vec::new();
-            reader.expect_tag(b"param", &mut buf)?;
-            let mut deserializer = ValueDeserializer::new(reader)?;
-            let ret = T::deserialize(&mut deserializer)?;
-            let mut reader = deserializer.into_inner();
+    match reader.read_event().map_err(error::ParseError::from)? {
+        Event::Start(e) if e.name() == QName(b"params") => {
+            reader.expect_tag(QName(b"param"))?;
+            reader.expect_tag(QName(b"value"))?;
+            let deserializer = ValueDeserializer::new(&mut reader)?;
+            let ret = T::deserialize(deserializer)?;
+            //let mut reader = deserializer.into_inner();
             reader
-                .read_to_end(b"param", &mut buf)
+                .read_to_end(QName(b"param"))
                 .map_err(error::ParseError::from)?;
             reader
-                .read_to_end(e.name(), &mut buf)
+                .read_to_end(e.name())
                 .map_err(error::ParseError::from)?;
             Ok(ret)
         }
-        Event::Start(e) if e.name() == b"fault" => {
+        Event::Start(e) if e.name() == QName(b"fault") => {
             // The inner portion of a fault is just a Value tag, so we
             // deserialize it from a value.
-            let mut deserializer = ValueDeserializer::new(reader)?;
-            let fault: Fault = Fault::deserialize(&mut deserializer)?;
+            reader.expect_tag(QName(b"value"))?;
+            let deserializer = ValueDeserializer::new(&mut reader)?;
+            let fault: Fault = Fault::deserialize(deserializer)?;
 
             // Pull the reader back out so we can verify the end tag.
-            let mut reader = deserializer.into_inner();
+            //let mut reader = deserializer.into_inner();
 
-            let mut buf = Vec::new();
             reader
-                .read_to_end(e.name(), &mut buf)
+                .read_to_end(e.name())
                 .map_err(error::ParseError::from)?;
 
             Err(fault.into())
@@ -99,14 +94,10 @@ pub fn request_from_str(request: &str) -> Result<(String, Vec<Value>)> {
     reader.trim_text(true);
 
     // Search for methodCall start
-    let mut buf = Vec::new();
     loop {
-        match reader
-            .read_event(&mut buf)
-            .map_err(error::ParseError::from)?
-        {
+        match reader.read_event().map_err(error::ParseError::from)? {
             Event::Decl(_) => continue,
-            Event::Start(e) if e.name() == b"methodCall" => {
+            Event::Start(e) if e.name() == QName(b"methodCall") => {
                 break;
             }
             e => return Err(error::ParseError::UnexpectedEvent(format!("{:?}", e)).into()),
@@ -117,52 +108,39 @@ pub fn request_from_str(request: &str) -> Result<(String, Vec<Value>)> {
     // in the xmlrpc request, I'm not certain that this is actually enforced by the
     // specification, but could find not counter example where it wasn't true... -Carter
 
-    let method_name = match reader
-        .read_event(&mut buf)
-        .map_err(error::ParseError::from)?
-    {
-        Event::Start(e) if e.name() == b"methodName" => {
-            let mut buf = Vec::new();
-            reader
-                .read_text(e.name(), &mut buf)
-                .map_err(error::ParseError::from)?
-        }
+    let method_name = match reader.read_event().map_err(error::ParseError::from)? {
+        Event::Start(e) if e.name() == QName(b"methodName") => reader
+            .read_text(e.name())
+            .map_err(error::ParseError::from)?,
         e => return Err(error::ParseError::UnexpectedEvent(format!("{:?}", e)).into()),
     };
 
-    match reader
-        .read_event(&mut buf)
-        .map_err(error::ParseError::from)?
-    {
-        Event::Start(e) if e.name() == b"params" => {
-            let mut buf = Vec::new();
+    match reader.read_event().map_err(error::ParseError::from)? {
+        Event::Start(e) if e.name() == QName(b"params") => {
             let mut params = Vec::new();
 
             let params = loop {
-                break match reader
-                    .read_event(&mut buf)
-                    .map_err(error::ParseError::from)?
-                {
+                break match reader.read_event().map_err(error::ParseError::from)? {
                     // Read each parameter into a Value
-                    Event::Start(e) if e.name() == b"param" => {
-                        let mut buf = Vec::new();
-                        let mut deserializer = ValueDeserializer::new(reader)?;
+                    Event::Start(e) if e.name() == QName(b"param") => {
+                        reader.expect_tag(QName(b"value"))?;
+                        let deserializer = ValueDeserializer::new(&mut reader)?;
                         let serializer = value::Serializer::new();
-                        let x = transcode(&mut deserializer, serializer)?;
+                        let x = transcode(deserializer, serializer)?;
                         params.push(x);
 
                         // Pull the reader back out so we can verify the end tag.
-                        reader = deserializer.into_inner();
+                        //reader = deserializer.into_inner();
 
                         reader
-                            .read_to_end(e.name(), &mut buf)
+                            .read_to_end(e.name())
                             .map_err(error::ParseError::from)?;
 
                         continue;
                     }
 
                     // Once we see the relevant params end tag, we know we have all the params.
-                    Event::End(e) if e.name() == b"params" => params,
+                    Event::End(e) if e.name() == QName(b"params") => params,
                     e => return Err(error::ParseError::UnexpectedEvent(format!("{:?}", e)).into()),
                 };
             };
@@ -170,7 +148,7 @@ pub fn request_from_str(request: &str) -> Result<(String, Vec<Value>)> {
             // We can skip reading to the end of the params tag because if we're
             // here, we've already hit the end tag.
 
-            Ok((method_name, params))
+            Ok((method_name.into_owned(), params))
         }
         e => Err(error::ParseError::UnexpectedEvent(format!("{:?}", e)).into()),
     }
@@ -183,27 +161,27 @@ pub fn request_from_str(request: &str) -> Result<(String, Vec<Value>)> {
 /// let body = serde_xmlrpc::request_to_string("myMethod", vec![1.into(), "param2".into()]);
 /// ```
 pub fn request_to_string(name: &str, args: Vec<Value>) -> Result<String> {
-    let mut writer = Writer::new(Vec::new());
-
-    writer
-        .write(br#"<?xml version="1.0" encoding="utf-8"?>"#)
+    let mut buf = Vec::new();
+    buf.write(br#"<?xml version="1.0" encoding="utf-8"?>"#)
         .map_err(error::EncodingError::from)?;
 
-    writer.write_start_tag(b"methodCall")?;
-    writer.write_tag(b"methodName", name)?;
+    let mut writer = Writer::new(buf);
 
-    writer.write_start_tag(b"params")?;
+    writer.write_start_tag("methodCall")?;
+    writer.write_tag("methodName", name)?;
+
+    writer.write_start_tag("params")?;
     for value in args {
-        writer.write_start_tag(b"param")?;
+        writer.write_start_tag("param")?;
 
         let deserializer = value::Deserializer::from_value(value);
         let serializer = ValueSerializer::new(&mut writer);
         transcode(deserializer, serializer)?;
 
-        writer.write_end_tag(b"param")?;
+        writer.write_end_tag("param")?;
     }
-    writer.write_end_tag(b"params")?;
-    writer.write_end_tag(b"methodCall")?;
+    writer.write_end_tag("params")?;
+    writer.write_end_tag("methodCall")?;
 
     Ok(String::from_utf8(writer.into_inner()).map_err(error::EncodingError::from)?)
 }
@@ -218,9 +196,10 @@ pub fn value_from_str(input: &str) -> Result<Value> {
     reader.expand_empty_elements(true);
     reader.trim_text(true);
 
-    let mut deserializer = ValueDeserializer::new(reader)?;
+    reader.expect_tag(QName(b"value"))?;
+    let deserializer = ValueDeserializer::new(&mut reader)?;
     let serializer = value::Serializer::new();
-    transcode(&mut deserializer, serializer)
+    transcode(deserializer, serializer)
 }
 
 /// Attempts to convert any data type which can be reprsented as an xmlrpc value into a String.

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::name::QName;
 use quick_xml::{Reader, Writer};
 
 use crate::error::{EncodingError, ParseError, Result};
@@ -12,23 +13,20 @@ pub use seq::{SeqDeserializer, SeqSerializer};
 pub use value::{Deserializer as ValueDeserializer, Serializer as ValueSerializer};
 
 pub(crate) trait ReaderExt {
-    fn expect_tag(&mut self, end: &[u8], buf: &mut Vec<u8>) -> Result<()>;
+    fn expect_tag(&mut self, end: QName) -> Result<()>;
 }
 
-impl<B> ReaderExt for Reader<B>
-where
-    B: std::io::BufRead,
-{
-    fn expect_tag(&mut self, end: &[u8], buf: &mut Vec<u8>) -> Result<()> {
+impl<'a> ReaderExt for Reader<&'a [u8]> {
+    fn expect_tag(&mut self, end: QName) -> Result<()> {
         loop {
-            match self.read_event(buf) {
+            match self.read_event() {
                 // TODO: this isn't exactly right, but it's good enough for now.
                 Ok(Event::Decl(ref _d)) => continue,
                 Ok(Event::Start(ref e)) => {
                     if e.name() != end {
                         return Err(ParseError::UnexpectedTag(
-                            String::from_utf8_lossy(e.name()).into(),
-                            String::from_utf8_lossy(end).into(),
+                            String::from_utf8_lossy(e.name().into_inner()).into(),
+                            String::from_utf8_lossy(end.into_inner()).into(),
                         )
                         .into());
                     }
@@ -38,14 +36,14 @@ where
                 Ok(_e) => {
                     return Err(ParseError::UnexpectedEvent(
                         //e,
-                        String::from_utf8_lossy(end).into(),
+                        String::from_utf8_lossy(end.into_inner()).into(),
                     )
                     .into());
                 }
                 Err(e) => {
                     return Err(ParseError::UnexpectedError(
                         e.into(),
-                        String::from_utf8_lossy(end).into(),
+                        String::from_utf8_lossy(end.into_inner()).into(),
                     )
                     .into())
                 }
@@ -58,14 +56,14 @@ where
 
 pub(crate) trait WriterExt {
     // High level functions
-    fn write_tag(&mut self, tag: &[u8], text: &str) -> Result<()> {
+    fn write_tag(&mut self, tag: &str, text: &str) -> Result<()> {
         self.write_start_tag(tag)?;
         self.write_text(text)?;
         self.write_end_tag(tag)?;
         Ok(())
     }
 
-    fn write_safe_tag(&mut self, tag: &[u8], text: &str) -> Result<()> {
+    fn write_safe_tag(&mut self, tag: &str, text: &str) -> Result<()> {
         self.write_start_tag(tag)?;
         self.write_safe_text(text)?;
         self.write_end_tag(tag)?;
@@ -73,8 +71,8 @@ pub(crate) trait WriterExt {
     }
 
     // Building blocks
-    fn write_start_tag(&mut self, tag: &[u8]) -> Result<()>;
-    fn write_end_tag(&mut self, tag: &[u8]) -> Result<()>;
+    fn write_start_tag(&mut self, tag: &str) -> Result<()>;
+    fn write_end_tag(&mut self, tag: &str) -> Result<()>;
     fn write_text(&mut self, text: &str) -> Result<()>;
     fn write_safe_text(&mut self, text: &str) -> Result<()>;
 }
@@ -83,24 +81,24 @@ impl<W> WriterExt for Writer<W>
 where
     W: std::io::Write,
 {
-    fn write_start_tag(&mut self, tag: &[u8]) -> Result<()> {
-        self.write_event(Event::Start(BytesStart::borrowed_name(tag)))
+    fn write_start_tag(&mut self, tag: &str) -> Result<()> {
+        self.write_event(Event::Start(BytesStart::new(tag)))
             .map_err(EncodingError::from)?;
         Ok(())
     }
 
-    fn write_end_tag(&mut self, tag: &[u8]) -> Result<()> {
-        self.write_event(Event::End(BytesEnd::borrowed(tag)))
+    fn write_end_tag(&mut self, tag: &str) -> Result<()> {
+        self.write_event(Event::End(BytesEnd::new(tag)))
             .map_err(EncodingError::from)?;
         Ok(())
     }
     fn write_text(&mut self, text: &str) -> Result<()> {
-        self.write_event(Event::Text(BytesText::from_plain_str(text)))
+        self.write_event(Event::Text(BytesText::new(text)))
             .map_err(EncodingError::from)?;
         Ok(())
     }
     fn write_safe_text(&mut self, text: &str) -> Result<()> {
-        self.write_event(Event::Text(BytesText::from_escaped_str(text)))
+        self.write_event(Event::Text(BytesText::from_escaped(text)))
             .map_err(EncodingError::from)?;
         Ok(())
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,4 @@
-use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 use quick_xml::{Reader, Writer};
 
@@ -71,6 +71,7 @@ pub(crate) trait WriterExt {
     }
 
     // Building blocks
+    fn write_decl(&mut self) -> Result<()>;
     fn write_start_tag(&mut self, tag: &str) -> Result<()>;
     fn write_end_tag(&mut self, tag: &str) -> Result<()>;
     fn write_text(&mut self, text: &str) -> Result<()>;
@@ -81,6 +82,12 @@ impl<W> WriterExt for Writer<W>
 where
     W: std::io::Write,
 {
+    fn write_decl(&mut self) -> Result<()> {
+        self.write_event(Event::Decl(BytesDecl::new("1.0", Some("utf-8"), None)))
+            .map_err(EncodingError::from)?;
+        Ok(())
+    }
+
     fn write_start_tag(&mut self, tag: &str) -> Result<()> {
         self.write_event(Event::Start(BytesStart::new(tag)))
             .map_err(EncodingError::from)?;

--- a/src/util/value.rs
+++ b/src/util/value.rs
@@ -382,9 +382,9 @@ where
 
 #[doc(hidden)]
 #[allow(dead_code)]
-pub fn from_str<T>(val: &str) -> Result<T>
+pub fn from_str<'a, T>(val: &'a str) -> Result<T>
 where
-    T: serde::de::DeserializeOwned,
+    T: serde::de::Deserialize<'a>,
 {
     let mut reader = Reader::from_str(val);
     reader.expand_empty_elements(true);


### PR DESCRIPTION
The big change happened in 0.24.

However, these tweaks *should* come with the following improvements:

* Usage of `quick_xml::Reader`'s internal buffer
* Much less unnecessary allocation (using the internal buffer means we no longer need to continuously allocate `Vec<u8>`s
* The ability to deserialize into non-owned objects, further reducing unnecessary copying
* More consistent internal usage of the deserializer classes - now you are expected to be inside the element before calling the relevant deserializer.

Downsides:

* While the API is pretty much the same, I believe this would technically require a version bump to 0.2.0
* There are some additional tweaks/cleanups that I think should be done before 0.2.0, like consolidating the Error types

Fixes #11

CC @Carter12s - I could use a review if you've got the time (though I do realize this is a pretty big PR), but it won't let me add you as a reviewer.