### PR TITLE
Add serde_xmlrpc::to_value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod value;
 use util::{ReaderExt, ValueDeserializer, ValueSerializer, WriterExt};
 
 pub use error::{Error, Fault, Result};
-pub use value::Value;
+pub use value::{to_value, Value};
 
 /// Parses the body of an xmlrpc http request and attempts to convert it to the desired type.
 /// ```

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -8,6 +8,30 @@ pub mod ser;
 pub use de::Deserializer;
 pub use ser::Serializer;
 
+/// Convert a `T` into `serde_xmlrpc::Value` which is an enum that can represent
+/// any valid JSON data.
+///
+/// # Example
+///
+/// ```
+/// #[derive(serde::Serialize)]
+/// struct Custom {
+///     field: i32,
+/// }
+///
+/// let param = Custom {
+///     field: 42
+/// };
+///
+/// let _value = serde_xmlrpc::to_value(param).unwrap();
+/// ```
+pub fn to_value<T>(value: T) -> crate::Result<Value>
+where
+    T: serde::Serialize,
+{
+    value.serialize(Serializer)
+}
+
 /// Represents any single valid xmlrpc "Value"
 #[derive(Clone, Debug, PartialEq)]
 pub enum Value {


### PR DESCRIPTION
This mirrors serde_json::to_value. Initially I attempted to add an implementation for TryFrom, but that results in trait implementation conflicts, so I took a look at serde_json and ended up with this solution.

Fixes #4